### PR TITLE
Add: kool and docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3.7"
+services:
+  app:
+    image: kooldev/node:18
+    command: ["npm", "run", "dev"]
+    ports:
+      - "${KOOL_APP_PORT:-3000}:5173"
+    environment:
+      ASUSER: "${KOOL_ASUSER:-0}"
+      UID: "${UID:-0}"
+    volumes:
+      - .:/app:delegated
+    networks:
+      - kool_local
+      - kool_global
+
+networks:
+  kool_local:
+  kool_global:
+    external: true
+    name: "${KOOL_GLOBAL_NETWORK:-kool_global}"

--- a/kool.yml
+++ b/kool.yml
@@ -1,0 +1,15 @@
+# Here you can define shortcuts and aliases to common tasks (commands)
+# you will run in your local environment or CI or deploy.
+#  Use the scripts defined below with:
+#    $ kool run <script>
+# Learn more at: https://kool.dev/docs/getting-started/how-it-works#koolyml
+scripts:
+  setup:
+    - cp .env.example .env
+    - kool docker kooldev/node:18 npm install
+    - kool start
+  reset:
+    - kool run npm install
+  # npm - helpers for JS handling
+  app:npm: kool docker kooldev/node:18 npm
+  app:npx: kool docker kooldev/node:18 npx

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host",
     "build": "tsc && vite build",
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"


### PR DESCRIPTION
Adds:
- [kool.dev](https://kool.dev/): a tool to make dealing with docker and scripts easy
- docker: running application into a container / avoid junk on local machine

Usage:

```bash
kool run setup
```

Brings the app alive on localhost:3000

